### PR TITLE
Created Kill Trigger and KillFloor

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -236,6 +236,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Ball
       objectReference: {fileID: 0}
+    - target: {fileID: 6658634041791577536, guid: 5ee31fe341240184ba75307c1b1da678, type: 3}
+      propertyPath: m_TagString
+      value: Player
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -335,6 +339,124 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &744036179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 744036184}
+  - component: {fileID: 744036183}
+  - component: {fileID: 744036182}
+  - component: {fileID: 744036185}
+  - component: {fileID: 744036180}
+  m_Layer: 0
+  m_Name: KillFloor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &744036180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 744036179}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ba2baeabf633aa46a8ffadc233ad502, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!23 &744036182
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 744036179}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &744036183
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 744036179}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &744036184
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 744036179}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -50, z: 0}
+  m_LocalScale: {x: 10000, y: 1, z: 10000}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &744036185
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 744036179}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10000, y: 1, z: 10000}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -562,3 +684,4 @@ SceneRoots:
   - {fileID: 1205256032}
   - {fileID: 365224720}
   - {fileID: 125434693}
+  - {fileID: 744036184}

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -13,10 +13,14 @@ public class Player : MonoBehaviour
     private Rigidbody rb;
     private Vector3 thrustDir;
 
+    // Startup Values
+    private Vector3 origin;
+
     // Start is called before the first frame update
     void Start()
     {
         rb = ball.GetComponent<Rigidbody>();
+        origin = transform.position;
     }
 
     // Update is called once per frame
@@ -76,8 +80,20 @@ public class Player : MonoBehaviour
     void ThrusterFollowBall()
     {
         Quaternion newRot = Quaternion.LookRotation(rb.velocity);
-        
+
         transform.position = ball.transform.position;
         transform.rotation = Quaternion.Lerp(transform.rotation, newRot, rotSpeed);
+    }
+
+    // Updates the Player's position back to its start position
+    void ResetPosition()
+    {
+        ball.transform.position = origin;
+        ThrusterFollowBall();
+    }
+
+    public void KillPlayer()
+    {
+        ResetPosition();
     }
 }

--- a/Assets/Scripts/PlayerKillTrigger.cs
+++ b/Assets/Scripts/PlayerKillTrigger.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerKillTrigger : MonoBehaviour
+{
+    private void OnTriggerEnter(Collider other)
+    {
+        // The player's ball collided
+        if (other.gameObject.tag == "Player")
+        {
+            // Grab the player's thruster that contains its properties
+            GameObject thruster = GameObject.Find("Thruster");
+            if (thruster != null)
+            {
+                // Grab the player's properties to perform its common kill action
+                Player props = thruster.GetComponent<Player>();
+                if (props != null)
+                {
+                    props.KillPlayer();
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/PlayerKillTrigger.cs
+++ b/Assets/Scripts/PlayerKillTrigger.cs
@@ -21,5 +21,9 @@ public class PlayerKillTrigger : MonoBehaviour
                 }
             }
         }
+        else
+        {
+            Debug.Log("Thruster failed to be found!");
+        }
     }
 }

--- a/Assets/Scripts/PlayerKillTrigger.cs.meta
+++ b/Assets/Scripts/PlayerKillTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ba2baeabf633aa46a8ffadc233ad502
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Created a Kill Floor that will reset the player's position to the startup origin.

What does this do:
- Kill Floor exists at Y=-20, below the start floor taking a large space to check for the player falling
- Kill Floor uses PlayerKillTrigger script to reset the player
- PlayerKillTrigger script can be used for any object that supports a trigger

What was changed:
- Created Kill Floor
- Created Kill PlayerKillFloor script
- Added KillPlayer function to Player script
- Added ResetPosition and origin to Player script